### PR TITLE
feat: 게시글 태그 조회 REST API 구현

### DIFF
--- a/src/main/java/com/qriositylog/algorio/domain/posts/Posts.java
+++ b/src/main/java/com/qriositylog/algorio/domain/posts/Posts.java
@@ -21,6 +21,8 @@ public class Posts {
     private String content;
 
     private String author;
+
+    @Column(nullable = false)
     private String tag;
 
     @Builder

--- a/src/main/java/com/qriositylog/algorio/service/posts/PostsService.java
+++ b/src/main/java/com/qriositylog/algorio/service/posts/PostsService.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service
@@ -37,13 +39,21 @@ public class PostsService {
         Posts entity = postsRepository.findById(id).orElseThrow(
                 () -> new IllegalArgumentException("해당 게시글이 없습니다.")
         );
-        return new PostsResponseDto(entity);
+        String tag = entity.getTag();
+        List<String> tagList = new ArrayList<>();
+        if (!Objects.equals(tag, "")) tagList = Arrays.asList(tag.split("\\s*,\\s*"));
+        return new PostsResponseDto(entity, tagList);
     }
 
     public List<PostsMetaResponseDto> findAll() {
         List<Posts> entities = postsRepository.findAll();
         List<PostsMetaResponseDto> metaList = new ArrayList<>(entities.size());
-        entities.forEach(entity -> metaList.add(new PostsMetaResponseDto(entity)));
+        for (Posts entity : entities) {
+            String tag = entity.getTag();
+            List<String> tagList = new ArrayList<>();
+            if (!Objects.equals(tag, "")) tagList = Arrays.asList(tag.split("\\s*,\\s*"));
+            metaList.add(new PostsMetaResponseDto(entity, tagList));
+        }
         return metaList;
     }
 }

--- a/src/main/java/com/qriositylog/algorio/service/posts/PostsService.java
+++ b/src/main/java/com/qriositylog/algorio/service/posts/PostsService.java
@@ -2,6 +2,7 @@ package com.qriositylog.algorio.service.posts;
 
 import com.qriositylog.algorio.domain.posts.Posts;
 import com.qriositylog.algorio.domain.posts.PostsRepository;
+import com.qriositylog.algorio.web.dto.PostsMetaResponseDto;
 import com.qriositylog.algorio.web.dto.PostsResponseDto;
 import com.qriositylog.algorio.web.dto.PostsSaveRequestDto;
 import com.qriositylog.algorio.web.dto.PostsUpdateRequestDto;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -35,5 +38,12 @@ public class PostsService {
                 () -> new IllegalArgumentException("해당 게시글이 없습니다.")
         );
         return new PostsResponseDto(entity);
+    }
+
+    public List<PostsMetaResponseDto> findAll() {
+        List<Posts> entities = postsRepository.findAll();
+        List<PostsMetaResponseDto> metaList = new ArrayList<>(entities.size());
+        entities.forEach(entity -> metaList.add(new PostsMetaResponseDto(entity)));
+        return metaList;
     }
 }

--- a/src/main/java/com/qriositylog/algorio/web/PostsApiController.java
+++ b/src/main/java/com/qriositylog/algorio/web/PostsApiController.java
@@ -1,11 +1,14 @@
 package com.qriositylog.algorio.web;
 
 import com.qriositylog.algorio.service.posts.PostsService;
+import com.qriositylog.algorio.web.dto.PostsMetaResponseDto;
 import com.qriositylog.algorio.web.dto.PostsResponseDto;
 import com.qriositylog.algorio.web.dto.PostsSaveRequestDto;
 import com.qriositylog.algorio.web.dto.PostsUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -29,4 +32,8 @@ public class PostsApiController {
     public PostsResponseDto findById(@PathVariable Long id) {
         return postsService.findById(id);
     }
+
+    // 모든 게시글 메타데이터 조회
+    @GetMapping("/api/v1/posts/all")
+    public List<PostsMetaResponseDto> findAll() { return postsService.findAll(); }
 }

--- a/src/main/java/com/qriositylog/algorio/web/dto/PostsMetaResponseDto.java
+++ b/src/main/java/com/qriositylog/algorio/web/dto/PostsMetaResponseDto.java
@@ -3,17 +3,19 @@ package com.qriositylog.algorio.web.dto;
 import com.qriositylog.algorio.domain.posts.Posts;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class PostsMetaResponseDto {
     private Long id;
     private String title;
     private String content;
-    private String tag;
+    private List<String> tags;
 
-    public PostsMetaResponseDto(Posts entity) {
+    public PostsMetaResponseDto(Posts entity, List<String> tagList) {
         id = entity.getId();
         title = entity.getTitle();
         content = entity.getContent();
-        tag = entity.getTag();
+        this.tags = tagList;
     }
 }

--- a/src/main/java/com/qriositylog/algorio/web/dto/PostsMetaResponseDto.java
+++ b/src/main/java/com/qriositylog/algorio/web/dto/PostsMetaResponseDto.java
@@ -1,0 +1,19 @@
+package com.qriositylog.algorio.web.dto;
+
+import com.qriositylog.algorio.domain.posts.Posts;
+import lombok.Getter;
+
+@Getter
+public class PostsMetaResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private String tag;
+
+    public PostsMetaResponseDto(Posts entity) {
+        id = entity.getId();
+        title = entity.getTitle();
+        content = entity.getContent();
+        tag = entity.getTag();
+    }
+}

--- a/src/main/java/com/qriositylog/algorio/web/dto/PostsResponseDto.java
+++ b/src/main/java/com/qriositylog/algorio/web/dto/PostsResponseDto.java
@@ -3,19 +3,21 @@ package com.qriositylog.algorio.web.dto;
 import com.qriositylog.algorio.domain.posts.Posts;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class PostsResponseDto {
     private Long id;
     private String title;
     private String content;
     private String author;
-    private String tag;
+    private List<String> tags;
 
-    public PostsResponseDto(Posts entity) {
+    public PostsResponseDto(Posts entity, List<String> tagList) {
         this.id = entity.getId();
         this.title = entity.getTitle();
         this.content = entity.getContent();
         this.author = entity.getAuthor();
-        this.tag = entity.getTag();
+        this.tags = tagList;
     }
 }

--- a/src/test/java/com/qriositylog/algorio/domain/posts/PostsRepositoryTest.java
+++ b/src/test/java/com/qriositylog/algorio/domain/posts/PostsRepositoryTest.java
@@ -27,13 +27,13 @@ public class PostsRepositoryTest {
         String title = "테스트 제목";
         String content = "테스트 내용";
         String author = "Queue-ri";
-        String tag = "";
+        String tag = ""; // intentionally null string
 
-        // intentionally excluded tag
         postsRepository.save(Posts.builder()
                 .title(title)
                 .content(content)
                 .author(author)
+                .tag(tag)
                 .build());
 
         List<Posts> postsList = postsRepository.findAll();
@@ -42,5 +42,6 @@ public class PostsRepositoryTest {
         assertThat(posts.getTitle()).isEqualTo(title);
         assertThat(posts.getContent()).isEqualTo(content);
         assertThat(posts.getAuthor()).isEqualTo(author);
+        assertThat(posts.getTag()).isEqualTo(tag);
     }
 }

--- a/src/test/java/com/qriositylog/algorio/web/PostsApiControllerTest.java
+++ b/src/test/java/com/qriositylog/algorio/web/PostsApiControllerTest.java
@@ -41,6 +41,7 @@ public class PostsApiControllerTest {
     String title = "테스트 타이틀";
     String content = "테스트 내용";
     String author = "Queue-ri";
+    String tag = "tag1, tag2";
 
     @Test
     public void TestPostsSave() throws Exception {
@@ -48,6 +49,7 @@ public class PostsApiControllerTest {
                 .title(title)
                 .content(content)
                 .author(author)
+                .tag(tag)
                 .build();
 
         String url = "http://localhost:" + port + "/api/v1/posts";
@@ -60,6 +62,7 @@ public class PostsApiControllerTest {
         List<Posts> all = postsRepository.findAll();
         assertThat(all.get(0).getTitle()).isEqualTo(title);
         assertThat(all.get(0).getContent()).isEqualTo(content);
+        assertThat(all.get(0).getTag()).isEqualTo(tag);
     }
 
     @Test
@@ -68,6 +71,7 @@ public class PostsApiControllerTest {
                 .title(title)
                 .content(content)
                 .author(author)
+                .tag(tag)
                 .build());
 
         Long updateId = savedPosts.getId();


### PR DESCRIPTION
- comma separator와 함께 `String`으로 저장
- Service에서 parsing 후 가공하여 dto 생성
- 1정규형 위배여도 태그가 복잡한게 아니라서 String으로 처리하는게 더 가볍지 않을까 싶은데...