### PR TITLE
feat: Add Google OAuth logic

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -24,4 +24,8 @@ jobs:
       run: chmod +x gradlew
       
     - name: Test with Gradle
-      run: ./gradlew test
+      run: ./gradlew test\
+        -PjvmArgs="\
+        -Dspring.security.oauth2.client.registration.google.client-id=${{ secrets.GOOGLE_CLIENT_ID }}\
+        -Dspring.security.oauth2.client.registration.google.client-secret=${{ secrets.GOOGLE_CLIENT_SECRET }}\
+        "

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM adoptopenjdk/openjdk11
 LABEL org.opencontainers.image.source https://github.com/SWIDX/Algorio-Backend
 ARG JAR_FILE=build/libs/*.jar
+ENV CLIENT_ID=
+ENV CLIENT_SECRET=
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT [ \
+    "java", \
+    "-Dspring.security.oauth2.client.registration.google.client-id=${CLIENT_ID}", \
+    "-Dspring.security.oauth2.client.registration.google.client-secret=${CLIENT_SECRET}", \
+    "-jar", \
+    "/app.jar" \
+    ]

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -35,4 +35,10 @@ dependencies {
 
 test {
 	useJUnitPlatform()
+
+	// Pass JVM arguments(i.e. -Dspring..) when gradle test
+	if ( project.hasProperty('jvmArgs') ) {
+		jvmArgs = (project.jvmArgs.split("\\s+") as List)
+
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'com.google.api-client:google-api-client:1.31.5'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation group: 'com.google.http-client', name: 'google-http-client-jackson2', version: '1.41.6'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'com.google.api-client:google-api-client:1.31.5'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation group: 'com.google.http-client', name: 'google-http-client-jackson2', version: '1.41.6'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'com.google.api-client:google-api-client:1.31.5'
+	implementation group: 'com.google.http-client', name: 'google-http-client-jackson2', version: '1.41.6'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/qriositylog/algorio/config/WebMvcConfig.java
+++ b/src/main/java/com/qriositylog/algorio/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.qriositylog.algorio.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration // Spring Bean
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final long MAX_AGE_SECS = 3600;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // all path
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(MAX_AGE_SECS);
+    }
+}

--- a/src/main/java/com/qriositylog/algorio/config/auth/AuthController.java
+++ b/src/main/java/com/qriositylog/algorio/config/auth/AuthController.java
@@ -1,0 +1,15 @@
+package com.qriositylog.algorio.config.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+    private final CustomOAuth2UserService userService;
+
+    @PostMapping("/auth/google")
+    public void loadUser(@RequestBody String idTokenString) { userService.loadUser(idTokenString); }
+}

--- a/src/main/java/com/qriositylog/algorio/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/qriositylog/algorio/config/auth/CustomOAuth2UserService.java
@@ -1,0 +1,109 @@
+package com.qriositylog.algorio.config.auth;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.qriositylog.algorio.config.auth.dto.OAuthAttributes;
+import com.qriositylog.algorio.domain.user.Role;
+import com.qriositylog.algorio.domain.user.User;
+import com.qriositylog.algorio.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService {
+    /* Replace login/oauth2/code/google controller since this is not available in my case */
+
+    private final UserRepository userRepository;
+    private static final HttpTransport transport = new NetHttpTransport();
+    private static final JsonFactory jsonFactory = new GsonFactory();
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String CLIENT_ID;
+
+    @Transactional
+    public User addUser(String email, String name, String pictureUrl) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .picture(pictureUrl)
+                .role(Role.USER)
+                .build();
+    }
+
+    public void loadUser(String idTokenString) throws OAuth2AuthenticationException {
+        GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
+                .setAudience(Collections.singletonList(CLIENT_ID))
+                // if multiple clients access the backend:
+                //.setAudience(Arrays.asList(CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3))
+                .build();
+
+        GoogleIdToken idToken;
+        try {
+            idToken = verifier.verify(idTokenString);
+
+            Payload payload = idToken.getPayload();
+
+            // Print user identifier
+            String userId = payload.getSubject();
+            System.out.println("User ID: " + userId);
+
+            // Get profile information from payload
+            String email = payload.getEmail();
+            boolean emailVerified = Boolean.valueOf(payload.getEmailVerified());
+            String name = (String) payload.get("name");
+            String pictureUrl = (String) payload.get("picture");
+            String locale = (String) payload.get("locale");
+            String familyName = (String) payload.get("family_name");
+            String givenName = (String) payload.get("given_name");
+
+            // Use or store profile information
+            System.out.println("email: " + email);
+            System.out.println("emailVerified: " + emailVerified);
+            System.out.println("name: " + name);
+            System.out.println("pictureUrl: " + pictureUrl);
+            System.out.println("locale: " + locale);
+            System.out.println("familyName: " + familyName);
+            System.out.println("givenName: " + givenName);
+
+            // Add or update user
+            User user = userRepository.findByEmail(email).orElseGet(
+                    () -> addUser(email, name, pictureUrl)
+            );
+
+        } catch (Exception e) {
+            System.out.println("Invalid ID token.");
+            System.out.println(e);
+        }
+/*        User user = saveOrUpdate(attributes);
+        httpSession.setAttribute("user", new SessionUser(user));
+
+        return new DefaultOAuth2User(
+                Collections.singleton(
+                        new SimpleGrantedAuthority(
+                                user.getRoleKey())),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey()); */
+    }
+
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/qriositylog/algorio/config/auth/SecurityConfig.java
+++ b/src/main/java/com/qriositylog/algorio/config/auth/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.qriositylog.algorio.config.auth;
+
+import com.qriositylog.algorio.domain.user.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .headers().frameOptions().disable()
+                .and()
+                .authorizeRequests()
+                .antMatchers("/","/css/**","/images/**","/js/**","/h2-console/**","/api/v1/posts/all","/auth/**").permitAll()
+                .antMatchers("/api/v1/posts").hasRole(Role.USER.name())
+                .anyRequest().authenticated();
+    }
+}

--- a/src/main/java/com/qriositylog/algorio/config/auth/dto/OAuthAttributes.java
+++ b/src/main/java/com/qriositylog/algorio/config/auth/dto/OAuthAttributes.java
@@ -1,0 +1,55 @@
+package com.qriositylog.algorio.config.auth.dto;
+
+import com.qriositylog.algorio.domain.user.Role;
+import com.qriositylog.algorio.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey,
+                           String name,
+                           String email,
+                           String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.GUEST)
+                .build();
+    }
+}

--- a/src/main/java/com/qriositylog/algorio/domain/posts/Posts.java
+++ b/src/main/java/com/qriositylog/algorio/domain/posts/Posts.java
@@ -20,6 +20,7 @@ public class Posts {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Column(nullable = false)
     private String author;
 
     @Column(nullable = false)

--- a/src/main/java/com/qriositylog/algorio/domain/user/Role.java
+++ b/src/main/java/com/qriositylog/algorio/domain/user/Role.java
@@ -1,0 +1,14 @@
+package com.qriositylog.algorio.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST", "게스트"),
+    USER("ROLE_USER", "회원");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/qriositylog/algorio/domain/user/User.java
+++ b/src/main/java/com/qriositylog/algorio/domain/user/User.java
@@ -1,0 +1,48 @@
+package com.qriositylog.algorio.domain.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column
+    private String picture;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    public User(String name, String email, String picture, Role role) {
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+        this.role = role;
+    }
+
+    public User update(String name, String picture) {
+        this.name = name;
+        this.picture = picture;
+
+        return this;
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+}

--- a/src/main/java/com/qriositylog/algorio/domain/user/UserRepository.java
+++ b/src/main/java/com/qriositylog/algorio/domain/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.qriositylog.algorio.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -1,0 +1,3 @@
+spring.security.oauth2.client.registration.google.client-id=
+spring.security.oauth2.client.registration.google.client-secret=
+spring.security.oauth2.client.registration.google.scope=profile,email

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.h2.console.enabled=true
 spring.datasource.generate-unique-name=false
+spring.profiles.include=oauth


### PR DESCRIPTION
- 프론트엔드에서 id token 받아 구글 서버에 인증하고 사용자 정보 가져오는 로직 구현
- JWT 생성 직전까지 구현 완료 (디펜던시는 추가됨)
---
Relates to #10.